### PR TITLE
Fix code scanning alert no. 8: Log entries created from user input

### DIFF
--- a/API/Middlewares/RequestResponseMiddleware.cs
+++ b/API/Middlewares/RequestResponseMiddleware.cs
@@ -60,7 +60,7 @@ namespace API.Middlewares
             // Read the stream as text
             var buffer = new byte[Convert.ToInt32(request.ContentLength)];
             await request.Body.ReadAsync(buffer, 0, buffer.Length);
-            var bodyAsText = Encoding.UTF8.GetString(buffer);
+            var bodyAsText = Encoding.UTF8.GetString(buffer).Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
             request.Body.Seek(0, SeekOrigin.Begin);
 
             var headers = string.Join("; ", request.Headers.Select(h => $"{h.Key}: {h.Value}"));


### PR DESCRIPTION
Fixes [https://github.com/th3y3m/badminton-bazaar/security/code-scanning/8](https://github.com/th3y3m/badminton-bazaar/security/code-scanning/8)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the user input to prevent log forging. This can be done using the `String.Replace` method to replace newline characters with an empty string. We will apply this sanitization to the `bodyAsText` variable before it is included in the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
