### PR TITLE
Fix code scanning alert no. 8: Log entries created from user input

### DIFF
--- a/API/Middlewares/RequestResponseMiddleware.cs
+++ b/API/Middlewares/RequestResponseMiddleware.cs
@@ -63,9 +63,13 @@ namespace API.Middlewares
             var bodyAsText = Encoding.UTF8.GetString(buffer).Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
             request.Body.Seek(0, SeekOrigin.Begin);
 
-            var headers = string.Join("; ", request.Headers.Select(h => $"{h.Key}: {h.Value}"));
+            var headers = string.Join("; ", request.Headers.Select(h => $"{h.Key}: {h.Value.ToString().Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "")}"));
 
-            return $"Method: {request.Method}, Path: {request.Path}, QueryString: {request.QueryString}, Headers: [{headers}], Body: {bodyAsText}";
+            var sanitizedMethod = request.Method.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            var sanitizedPath = request.Path.ToString().Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            var sanitizedQueryString = request.QueryString.ToString().Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+
+            return $"Method: {sanitizedMethod}, Path: {sanitizedPath}, QueryString: {sanitizedQueryString}, Headers: [{headers}], Body: {bodyAsText}";
         }
 
         private async Task<string> FormatResponse(HttpResponse response)


### PR DESCRIPTION
Fixes [https://github.com/th3y3m/badminton-bazaar/security/code-scanning/8](https://github.com/th3y3m/badminton-bazaar/security/code-scanning/8)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any new line characters from the headers and other parts of the request to prevent log forging. This can be done by replacing new line characters with an empty string. Additionally, we should ensure that any other potentially dangerous characters are handled appropriately.

1. Modify the `FormatRequest` method to sanitize the headers and other parts of the request.
2. Use `String.Replace` to remove new line characters from the headers and other parts of the request.
3. Ensure that the sanitized data is used in the log entry.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
